### PR TITLE
refactor parseMany function to accept general functions rather than stri...

### DIFF
--- a/closure_conversion.js
+++ b/closure_conversion.js
@@ -151,8 +151,8 @@ function test(src) {
   console.log(JSON.stringify(closure_convert_all(ast), null, 4));
 }
 
-//console.log(test(pprint.pprint(parser.parse(pprint.pprint(parser.parse("if something then if a then if b then c else d else rtrrt else some_other_thing")[0]))[0])));
-//console.log(pprint.pprint(parser.parse("def main (print let { a = def {f = (lambda a b -> (a+b))} f} (a 2 3))")[0]));
+console.log(pprint.pprint(parser.parse(pprint.pprint(parser.parse("if something then if a then if b then c else d else rtrrt else some_other_thing")[0]))[0]));
+console.log(pprint.pprint(parser.parse("def main (print let { a = def {f = (lambda a b -> (a+b))} f} (a 2 3))")[0]));
 module.export = {
   test : test,
   closureConvert : closure_convert_all


### PR DESCRIPTION
...ngs, this is done in order to handle -> as an identifier rather than its own token
